### PR TITLE
Expand server with peer management endpoints

### DIFF
--- a/cmd/p2pweb/main.go
+++ b/cmd/p2pweb/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/example/p2pweb/internal/server"
+)
+
+func main() {
+	addr := ":8080"
+	log.Printf("listening on %s", addr)
+	s := server.New()
+	if err := http.ListenAndServe(addr, s.Handler()); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/p2pweb
+
+go 1.24.3

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// Server provides HTTP handlers for managing peers.
+type Server struct {
+	mu    sync.Mutex
+	peers []string
+}
+
+// New returns a ready-to-use Server.
+func New() *Server { return &Server{} }
+
+// Handler exposes HTTP endpoints for the server.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "p2p web placeholder")
+	})
+	mux.HandleFunc("/peers", s.peersHandler)
+	return mux
+}
+
+func (s *Server) peersHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.mu.Lock()
+		peers := append([]string(nil), s.peers...)
+		s.mu.Unlock()
+		if err := json.NewEncoder(w).Encode(peers); err != nil {
+			http.Error(w, "encode", http.StatusInternalServerError)
+		}
+	case http.MethodPost:
+		var req struct {
+			Addr string `json:"addr"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		s.mu.Lock()
+		s.peers = append(s.peers, req.Addr)
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandlerRoot(t *testing.T) {
+	s := New()
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET root failed: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	expected := "p2p web placeholder\n"
+	if string(b) != expected {
+		t.Fatalf("expected %q got %q", expected, b)
+	}
+}
+
+func TestPeersEndpoint(t *testing.T) {
+	s := New()
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	// initial list should be empty
+	resp, err := http.Get(ts.URL + "/peers")
+	if err != nil {
+		t.Fatalf("GET peers: %v", err)
+	}
+	var peers []string
+	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+		t.Fatalf("decode peers: %v", err)
+	}
+	resp.Body.Close()
+	if len(peers) != 0 {
+		t.Fatalf("expected empty peers, got %v", peers)
+	}
+
+	// post a new peer
+	body := bytes.NewBufferString(`{"addr":"peer1"}`)
+	resp, err = http.Post(ts.URL+"/peers", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST peer: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201 got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// verify list
+	resp, err = http.Get(ts.URL + "/peers")
+	if err != nil {
+		t.Fatalf("GET peers: %v", err)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+		t.Fatalf("decode peers: %v", err)
+	}
+	resp.Body.Close()
+	if len(peers) != 1 || peers[0] != "peer1" {
+		t.Fatalf("unexpected peers: %v", peers)
+	}
+}


### PR DESCRIPTION
## Summary
- add `Server` type with in-memory peer list and /peers API
- update main to use the new server instance
- test root handler and peer endpoints

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ab5091a6c8332bd2a9f1f1fca0c67